### PR TITLE
Fix mws/jsonp.t test for Plack >= 1.0031

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ my %params = (
     PREREQ_PM     => {
         'Test::More'            => '0.47',
         'Test::UseAllModules'   => '0.10',
-        'Plack'                 => '0.9945',
+        'Plack'                 => '1.0031',
         'Mojolicious'           => '5.08',
     },
     BUILD_REQUIRES => {

--- a/t/mws/jsonp.t
+++ b/t/mws/jsonp.t
@@ -23,7 +23,7 @@ use Test::More tests => 16;
     $t->get_ok('/hash?json.p=foo')
         ->status_is(200)
         ->header_is('Content-Type', 'text/javascript')
-        ->content_is(q(foo({"foo":"bar"})));
+        ->content_is(q(/**/foo({"foo":"bar"})));
     $t->get_ok('/array')
         ->status_is(200)
         ->header_is('Content-Type', 'application/json')
@@ -31,7 +31,7 @@ use Test::More tests => 16;
     $t->get_ok('/array?json.p=foo')
         ->status_is(200)
         ->header_is('Content-Type', 'text/javascript')
-        ->content_is(q(foo(["hoo","bar"])));
+        ->content_is(q(/**/foo(["hoo","bar"])));
 }
     {
         package SomeApp;


### PR DESCRIPTION
That Plack version fixed the Rosetta Flash Attack and changed the output in JSONP middleware.
